### PR TITLE
MailAttributes.From property may be null

### DIFF
--- a/src/ActionMailerNext/Implementations/SMTP/SmtpMailSender.cs
+++ b/src/ActionMailerNext/Implementations/SMTP/SmtpMailSender.cs
@@ -55,7 +55,7 @@ namespace ActionMailerNext.Implementations.SMTP
                 message.ReplyToList.Add(mail.ReplyTo[i]);
 
             // From is optional because it could be set in <mailSettings>
-            if (!String.IsNullOrWhiteSpace(mail.From.Address))
+            if (!String.IsNullOrWhiteSpace(mail.From?.Address))
                 message.From = new MailAddress(mail.From.Address, mail.From.DisplayName);
 
 


### PR DESCRIPTION
As MailAttributes.From is optional, allowed the 'From' property to be null. Otherwise,
a NullReferenceException occurs when attempting to access
'mail.From.Address' in 'ActionMailerNext.Implementations.SMTP.SmtpMailSender.GenerateProspectiveMailMessage'